### PR TITLE
fix(deps): react-router 7.17.0 -> 7.18.2

### DIFF
--- a/packages/digital-office/package.json
+++ b/packages/digital-office/package.json
@@ -50,6 +50,6 @@
         "prettier": "3.8.4",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
     }
 }


### PR DESCRIPTION
`react-router` **7.17.0 → 7.18.2** dans `@digital-net-org/digital-office`.

Ferme 5 constats de l'audit sécurité du 2026-08-09 de `safaridigital.fr-digital.net` :

| Avis | Sévérité | Sujet |
|---|---|---|
| GHSA-qwww-vcr4-c8h2 | HIGH | Contournement CSRF en mode RSC : l'action s'exécute **avant** la réponse 400 |
| CVE-2026-55685 | HIGH · 7.5 | DoS via requêtes non authentifiées sur l'endpoint manifest |
| CVE-2026-53666 | MEDIUM · 6.1 | Divulgation d'information via exécution de constructeur côté client |
| CVE-2026-53667 | MEDIUM · 6.9 | Redirections non fiables, validation de protocole manquante |
| CVE-2026-53669 | MEDIUM · 6.1 | Open redirect via antislashs dans les composants de navigation |

Le premier correctif est **7.18.0** ; **7.18.2** est la dernière de la ligne 7.x. On reste volontairement en 7.x — la `latest` est 8.3.0, une majeure hors périmètre d'un correctif de sécurité.

`react-router` est déclaré ici et non dans l'app qui le consomme (`office.safaridigital.fr`), d'où la correction dans ce dépôt.

## Vérifications

- `vite build` de `digital-office` → OK
- build de `office.safaridigital.fr`, qui consomme la lib → OK
- suite `vitest` : 47 tests passent

> À noter, sans rapport avec cette PR : la suite `publicSurface.test.ts` échoue sous Windows. Elle fait `import.meta.url.slice('file://'.length)`, ce qui laisse un slash en tête (`/C:/Users/...`) et empêche `ts.createProgram` de résoudre l'entrypoint. `fileURLToPath` corrigerait ça. Le bug est indépendant de toute version de paquet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
